### PR TITLE
Fix remapping keybindings not working as expected

### DIFF
--- a/lib/common/prefs/app_cache.dart
+++ b/lib/common/prefs/app_cache.dart
@@ -10,6 +10,8 @@ class AppCache {
   static const alwaysOnTop = BoolPref("alwaysOnTop", false);
   static const isMarkdownView = BoolPref("isMarkdownView", false);
 
+  static const openWindowKey = StringPref("openWindowKey");
+
   static const windowX = IntPref("windowX");
   static const windowY = IntPref("windowY");
   static const windowWidth = IntPref("windowWidth");
@@ -30,3 +32,5 @@ class AppCache {
   static const gptToolCopyToClipboardEnabled =
       BoolPref("copyToClipboardEnabled", true);
 }
+
+

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
@@ -10,6 +11,7 @@ import 'package:fluent_gpt/pages/overlay_settings_page.dart';
 import 'package:fluent_gpt/providers/chat_gpt_provider.dart';
 import 'package:fluent_gpt/shell_driver.dart';
 import 'package:fluent_gpt/tray.dart';
+import 'package:fluent_gpt/widgets/keybinding_dialog.dart';
 import 'package:fluent_gpt/widgets/message_list_tile.dart';
 import 'package:fluent_gpt/widgets/page.dart';
 import 'package:fluent_gpt/widgets/wiget_constants.dart';
@@ -24,6 +26,8 @@ import 'package:system_tray/system_tray.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../theme.dart';
+
+
 
 class GptModelChooser extends StatefulWidget {
   const GptModelChooser({super.key, required this.onChanged});
@@ -451,8 +455,6 @@ class _HotKeySection extends StatefulWidget {
 }
 
 class _HotKeySectionState extends State<_HotKeySection> {
-  bool isChoosingHotkey = false;
-
   @override
   Widget build(BuildContext context) {
     // ignore: unused_local_variable
@@ -464,52 +466,29 @@ class _HotKeySectionState extends State<_HotKeySection> {
       children: [
         Text('Hotkeys', style: FluentTheme.of(context).typography.subtitle),
         spacer,
-        if (isChoosingHotkey)
-          Text(
-            'Press a key combination to set a new hotkey (escape to cancel)',
-            style: FluentTheme.of(context).typography.caption,
+        Button(
+          onPressed: () async {
+            final key = await KeybindingDialog.show(
+              context,
+              initHotkey: openWindowHotkey,
+              title: const Text('Open the window keybinding'),
+            );
+            if (key != null && key != openWindowHotkey) {
+              setState(() {
+                openWindowHotkey = key;
+              });
+              await AppCache.openWindowKey.set(jsonEncode(key.toJson()));
+              initShortcuts(AppWindow());
+            }
+          },
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('Open the window'),
+              const SizedBox(width: 10.0),
+              HotKeyVirtualView(hotKey: openWindowHotkey),
+            ],
           ),
-        Row(
-          children: [
-            Button(
-              onPressed: () {
-                setState(() {
-                  isChoosingHotkey = true;
-                });
-              },
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Text('Open the window'),
-                  const SizedBox(width: 10.0),
-                  isChoosingHotkey
-                      ? HotKeyRecorder(
-                          onHotKeyRecorded: (v) async {
-                            // print('onHotKeyRecorded: $v');
-
-                            /// if escape is pressed, the value will be null
-                            if (v.physicalKey == PhysicalKeyboardKey.escape) {
-                              setState(() {
-                                isChoosingHotkey = false;
-                              });
-                              return;
-                            }
-                            if (mounted) {
-                              await hotKeyManager.unregister(openWindowHotkey);
-                              setState(() {
-                                openWindowHotkey = v;
-                                isChoosingHotkey = false;
-                              });
-                              initShortcuts(AppWindow());
-                            }
-                          },
-                          initalHotKey: openWindowHotkey,
-                        )
-                      : HotKeyVirtualView(hotKey: openWindowHotkey),
-                ],
-              ),
-            ),
-          ],
         ),
         spacer,
       ],
@@ -901,3 +880,4 @@ class __CacheSectionState extends State<_CacheSection> {
     );
   }
 }
+

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -457,10 +457,6 @@ class _HotKeySection extends StatefulWidget {
 class _HotKeySectionState extends State<_HotKeySection> {
   @override
   Widget build(BuildContext context) {
-    // ignore: unused_local_variable
-    final appTheme = context.watch<AppTheme>();
-
-    /// a button to add a new hotkey
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/widgets/keybinding_dialog.dart
+++ b/lib/widgets/keybinding_dialog.dart
@@ -1,0 +1,92 @@
+
+
+import 'package:fluent_gpt/widgets/wiget_constants.dart';
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/services.dart';
+import 'package:hotkey_manager/hotkey_manager.dart';
+
+class KeybindingDialog extends StatefulWidget {
+  const KeybindingDialog({super.key, this.initHotkey, this.title});
+  final HotKey? initHotkey;
+  final Widget? title;
+
+  static Future<HotKey?> show(
+    BuildContext context, {
+    HotKey? initHotkey,
+    Widget? title,
+  }) {
+    return showDialog<HotKey>(
+      context: context,
+      builder: (context) => KeybindingDialog(
+        initHotkey: initHotkey,
+        title: title,
+      ),
+    );
+  }
+
+  @override
+  State<KeybindingDialog> createState() => _KeybindingDialogState();
+}
+
+class _KeybindingDialogState extends State<KeybindingDialog> {
+  HotKey? hotKey;
+  @override
+  void initState() {
+    hotKey = widget.initHotkey;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ContentDialog(
+
+      title: widget.title ?? const Text('Choose a hotkey'),
+      constraints: const BoxConstraints(maxWidth: 400, maxHeight: 280),
+      actions: [
+        Button(
+          onPressed: () => Navigator.of(context).pop(widget.initHotkey),
+          child: const Text('Cancel'),
+        ),
+        Button(
+          onPressed: apply,
+          child: const Text('Apply'),
+        ),
+      ],
+      content: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (hotKey == null)
+              const Text(
+                  'Press a key combination to set a new hotkey (escape to cancel)'),
+            const Text('Current hotkey:'),
+            spacer,
+            HotKeyRecorder(
+              onHotKeyRecorded: (v) async {
+                if (v.physicalKey == PhysicalKeyboardKey.escape) {
+                  cancel();
+                  return;
+                }
+                setState(() {
+                  hotKey = v;
+                });
+              },
+              initalHotKey: hotKey,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void cancel() {
+    setState(() {
+      hotKey = widget.initHotkey;
+    });
+  }
+
+  void apply() {
+    Navigator.of(context).pop(hotKey);
+  }
+}
+


### PR DESCRIPTION
This pull request fixes the issue where remapping keybindings stopped working. The issue was that it captured the first key and then immediately stopped listening.

The changes in this pull request include:

- Added a new keybinding dialog

- Fixed the open window keybinding

- Added openWindowHotkey to cache

- Removed unused code in the _HotKeySection build method

fixes #1